### PR TITLE
fix: attribute disappears

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default (options = {}) => {
         tree.walk(node => {
             if (node.tag && node.attrs) {
                 node.attrs = Object.keys(node.attrs).reduce((attributeList, attr) => {
-                    if (tags.includes(node.tag) || attributes.includes(attr)) {
+                    if (tags.includes(node.tag) && attributes.includes(attr)) {
                         return Object.assign(attributeList, {[attr]: setNanoid(node.attrs[attr])});
                     }
 

--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -49,7 +49,7 @@ test('should add nanoid to iframe links', async t => {
 
 test('should add nanoid to custome attribute', async t => {
     const input = '<img data-src="lorem.png" alt="attribute not removed"/>';
-    const html = (await processing(input, {tags: ['iframe'], attributes: ['data-src']})).html;
+    const html = (await processing(input, {tags: ['img'], attributes: ['data-src']})).html;
 
     const id = queryString.parse(parser(html)[0].attrs['data-src'].split('?')[1]).v;
     const alt = parser(html)[0].attrs.alt;


### PR DESCRIPTION
I found attributes disappears bug.

before processing
```
<link rel="stylesheet" href="style.css">
```

after processing
```
<link href="style.css">
```

as a result, CSS is no longer recognized by the browser.