### PR TITLE
`foo.bar` added if url starts with `/`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,60 +4,60 @@ import queryString from 'query-string';
 import normalizeUrl from 'normalize-url';
 
 const setNanoid = url => {
-    const id = nanoid();
-    const fullUrl = /^[/?]/.test(url) ? `foo.bar${url}` : url;
+  const id = nanoid();
+  const fullUrl = /^[/?]/.test(url) ? `foo.bar${url}` : url;
 
-    if (!isUrl(normalizeUrl(fullUrl))) {
-        return url;
-    }
+  if (!isUrl(normalizeUrl(fullUrl))) {
+    return url;
+  }
 
-    let [uri, query] = fullUrl.split('?');
-    query = queryString.parse(query);
-    query.v = query.v ? query.v : id;
-    query = queryString.stringify(query);
+  let [uri, query] = fullUrl.split('?');
+  query = queryString.parse(query);
+  query.v = query.v ? query.v : id;
+  query = queryString.stringify(query);
 
-    return `${uri}?${query}`;
+  return `${uri}?${query}`;
 };
 
 export default (options = {}) => {
-    return tree => new Promise((resolve, reject) => {
-        let tags = ['link', 'script'];
-        let attributes = ['href', 'src'];
+  return tree => new Promise((resolve, reject) => {
+    let tags = ['link', 'script'];
+    let attributes = ['href', 'src'];
 
-        if (options.tags && Array.isArray(options.tags)) {
-            tags = [...new Set([...tags, ...options.tags])];
-        }
+    if (options.tags && Array.isArray(options.tags)) {
+      tags = [...new Set([...tags, ...options.tags])];
+    }
 
-        if (options.exclude) {
-            tags = tags.filter(tag => !options.exclude.includes(tag));
-        }
+    if (options.exclude) {
+      tags = tags.filter(tag => !options.exclude.includes(tag));
+    }
 
-        if (options.attributes && Array.isArray(options.attributes)) {
-            attributes = [...new Set([...attributes, ...options.attributes])];
-        }
+    if (options.attributes && Array.isArray(options.attributes)) {
+      attributes = [...new Set([...attributes, ...options.attributes])];
+    }
 
-        if (!Array.isArray(tree)) {
-            reject(new Error(`tree is not Array`));
-        }
+    if (!Array.isArray(tree)) {
+      reject(new Error('tree is not Array'));
+    }
 
-        if (tree.length === 0) {
-            resolve(tree);
-        }
+    if (tree.length === 0) {
+      resolve(tree);
+    }
 
-        tree.walk(node => {
-            if (node.tag && node.attrs) {
-                node.attrs = Object.keys(node.attrs).reduce((attributeList, attr) => {
-                    if (tags.includes(node.tag) && attributes.includes(attr)) {
-                        return Object.assign(attributeList, {[attr]: setNanoid(node.attrs[attr])});
-                    }
+    tree.walk(node => {
+      if (node.tag && node.attrs) {
+        node.attrs = Object.keys(node.attrs).reduce((attributeList, attr) => {
+          if (tags.includes(node.tag) && attributes.includes(attr)) {
+            return Object.assign(attributeList, {[attr]: setNanoid(node.attrs[attr])});
+          }
 
-                    return attributeList;
-                }, node.attrs);
-            }
+          return attributeList;
+        }, node.attrs);
+      }
 
-            return node;
-        });
-
-        resolve(tree);
+      return node;
     });
+
+    resolve(tree);
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const setNanoid = url => {
     return url;
   }
 
-  let [uri, query] = fullUrl.split('?');
+  let [uri, query] = url.split('?');
   query = queryString.parse(query);
   query.v = query.v ? query.v : id;
   query = queryString.stringify(query);


### PR DESCRIPTION
If I have a

```
<script src="/script.js"></script>
```

then it gets changed to:

```
<script src="foo.bar/script.js?v=3DW9E4NGiPsIFRZipbZYR"></script>
```

It breaks the link. I guess that `foo.bar` is added to let `normalizeUrl()` work, but later it's only disturbing.

I fixed that by changing line 14 from

```
let [uri, query] = fullUrl.split('?');
```

to

```
let [uri, query] = url.split('?');
```

fixes #20 