### PR TITLE
Added option `onlyInternal` which excludes external links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5188,16 +5188,6 @@
         "eslint-rule-composer": "^0.3.0"
       }
     },
-    "eslint-plugin-dependencies": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-dependencies/-/eslint-plugin-dependencies-2.4.0.tgz",
-      "integrity": "sha512-IaW2phNpktrok2eDziZLYxmNaGysXjNj6NVji7LEv/qagHG2oshsmV+mUSxAGG5Jv9seuRBdX1YXEIaNlhkFJg==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "resolve": "^1.1.6"
-      }
-    },
     "eslint-plugin-html": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.0.0.tgz",
@@ -7850,6 +7840,11 @@
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
       "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
       "dev": true
+    },
+    "is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "style"
   ],
   "dependencies": {
+    "is-absolute-url": "^3.0.3",
     "is-url": "^1.2.4",
     "nanoid": "^3.0.2",
     "normalize-url": "5.0.0",

--- a/readme.md
+++ b/readme.md
@@ -66,16 +66,21 @@ output.html
 ## Options
 
 ### `tags`
-Type: `Array`  
-Default: `['script', 'link']`  
-Description: *You can also expand the list by adding the tags you need...*  
+Type: `Array`
+Default: `['script', 'link']`
+Description: *You can also expand the list by adding the tags you need...*
 
 ### `attributes`
-Type: `Array`  
-Default: `['src', 'href']` 
-Description: *You can also expand the list by adding the attributes you need...*  
+Type: `Array`
+Default: `['src', 'href']`
+Description: *You can also expand the list by adding the attributes you need...*
 
 ### `exclude`
-Type: `Array`  
-Default: `[]`  
-Description: *You can also exclude the list by adding the tags you need...*  
+Type: `Array`
+Default: `[]`
+Description: *You can also exclude the list by adding the tags you need...*
+
+### `onlyInternal`
+Type: `Array`
+Default: `[]`
+Description: *If you have external URL-s, some won't work if you add nanoid to them. If this list is empty, all external links are modified. Otherwise, only the URL-s starting with items in the array (case insensitive) will be modified. E.g. `['https://github.com/']` will add nanoid to all local links and only to `https://github.com/*`. It won't add nanoid to e.g. `http://github.com` or  `https://fonts.google.com`. For simplicity, a link is considered external if it starts with a protocol (see [is-absolute-url](https://www.npmjs.com/package/is-absolute-url)) or with double slash `//`.*


### PR DESCRIPTION
Some links to external sites shouldn't be enhanced with nano id. E.g. AddThis doesn't work if the `v=...` parameter is added.

I added a new option: `onlyInternal`. It's an array with URLs. If it's empty, the library behaves as previously.

If `onlyInternal` contains items, all external links (`https://...` etc.) will be filtered against that list. See the README and tests for examples.